### PR TITLE
build for musl target on docker and switch to Google's `distroless` container images for better security and size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-.gitignore

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -2,8 +2,9 @@ name: Publish container
 
 on:
   push:
-    paths: |
-      eight-serve/
+    paths:
+      - eight-serve/
+      - Dockerfile
   release:
     types: [created]
 

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -3,16 +3,16 @@ name: Run examples
 on:
   push:
     branches: [main]
-    paths: |
-      eight/
-      eight-serve/
-      examples/
+    paths:
+      - eight/
+      - eight-serve/
+      - examples/
   pull_request:
     branches: [main]
-    paths: |
-      eight/
-      eight-serve/
-      examples/
+    paths:
+      - eight/
+      - eight-serve/
+      - examples/
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,14 +3,14 @@ name: Run tests
 on:
   push:
     branches: [main]
-    paths: |
-      eight/
-      eight-serve/
+    paths:
+      - eight/
+      - eight-serve/
   pull_request:
     branches: [main]
-    paths: |
-      eight/
-      eight-serve/
+    paths:
+      - eight/
+      - eight-serve/
 
 env:
   CARGO_TERM_COLOR: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM docker.io/rust:1.69 AS builder
-
-WORKDIR /app
-COPY . .
+FROM docker.io/rust:1.69-alpine AS builder
 
 WORKDIR /app/eight-serve
-RUN cargo build --release
+COPY eight-serve .
 
-FROM debian:bullseye-slim
+RUN apk add --no-cache musl-dev openssl-dev pkgconfig
+RUN cargo build --release --target x86_64-unknown-linux-musl
 
-COPY --from=builder /app/eight-serve/target/release/eight-serve /release/eight-serve
-ENTRYPOINT [ "/release/eight-serve" ]
+FROM gcr.io/distroless/static
+
+COPY --from=builder /app/eight-serve/target/x86_64-unknown-linux-musl/release/eight-serve /bin/eight-serve
+ENTRYPOINT [ "/bin/eight-serve" ]


### PR DESCRIPTION
also fixes wrong path inputs on workflows from previous pr (#2)