### PR TITLE
Patches for Eight Query Language

### DIFF
--- a/eight/src/embedded/language/lexer.rs
+++ b/eight/src/embedded/language/lexer.rs
@@ -1,7 +1,7 @@
 use super::token::Token;
 use std::mem;
 
-#[derive(Default)]
+#[derive(Default, PartialEq)]
 enum State {
     String,
     #[default]
@@ -103,17 +103,18 @@ impl Lexer {
     }
 
     fn make_token(&mut self) {
-        self.state = State::default();
-
-        if !self.temp.is_empty() {
-            let token = Token {
-                value: mem::take(&mut self.temp),
-                line: self.line,
-                column: self.column,
-            };
-
-            self.tokens.push(token);
+        let old_state = mem::take(&mut self.state);
+        if self.temp.is_empty() && old_state != State::String {
+            return;
         }
+
+        let token = Token {
+            value: mem::take(&mut self.temp),
+            line: self.line,
+            column: self.column,
+        };
+
+        self.tokens.push(token);
     }
 }
 

--- a/eight/src/embedded/language/parser.rs
+++ b/eight/src/embedded/language/parser.rs
@@ -32,16 +32,18 @@ impl Parser {
             false
         };
 
+        // manually implemented to prevent string allocation for every single query.
+        // also for only accepting full uppercase. SeT or ExisTs is not a valid command.
         let request = match command_name.as_str() {
-            "set" => self.parse_set(tokens),
-            "get" => self.parse_get(tokens),
-            "delete" => self.parse_delete(tokens),
-            "exists" => self.parse_exists(tokens),
-            "incr" => self.parse_increment(tokens),
-            "decr" => self.parse_decrement(tokens),
-            "search" => self.parse_search(tokens),
-            "flush" => self.parse_flush(tokens),
-            "downgrade" => self.parse_downgrade(tokens),
+            "set" | "SET" => self.parse_set(tokens),
+            "get" | "GET" => self.parse_get(tokens),
+            "delete" | "DELETE" => self.parse_delete(tokens),
+            "exists" | "EXISTS" => self.parse_exists(tokens),
+            "incr" | "INCR" => self.parse_increment(tokens),
+            "decr" | "DECR" => self.parse_decrement(tokens),
+            "search" | "SEARCH" => self.parse_search(tokens),
+            "flush" | "FLUSH" => self.parse_flush(tokens),
+            "downgrade" | "DOWNGRADE" => self.parse_downgrade(tokens),
             _ => Err(err!("Command not found", command)),
         }?;
 


### PR DESCRIPTION
This pull request includes small patches and fixes for eight query language.

* Lexer was skipping empty strings, which is good but for `search` command we may want to use an empty string. So you can now initialize an empty string with quotes (`""`).
* Add UPPERCASE support for commands. Now you can also use commands like this: `GET "wow";`