### PR TITLE
Bump version to v1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
-# v1.0.0-beta
+# v1.0.0-alpha.2
+
+- UPPERCASE support for commands
+- Fixed empty string tokenization
+- Added language tests (@sum12)
+- Improved container image (@tuhanayim)
+
+# v1.0.0-alpha
 
 First public release.

--- a/eight-serve/Cargo.lock
+++ b/eight-serve/Cargo.lock
@@ -179,9 +179,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "eight-serve"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "eight",

--- a/eight-serve/Cargo.toml
+++ b/eight-serve/Cargo.toml
@@ -14,4 +14,4 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 [dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "signal"] }
 eight = { version = "1.0.0-alpha.2", features = ["expose"] }
-clap = { version = "4.2", features = ["derive"] }
+clap = { version = "4.3", features = ["derive"] }

--- a/eight-serve/Cargo.toml
+++ b/eight-serve/Cargo.toml
@@ -13,5 +13,5 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 
 [dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "signal"] }
-eight = { version = "1.0.0-alpha", features = ["expose"] }
+eight = { version = "1.0.0-alpha.2", features = ["expose"] }
 clap = { version = "4.3", features = ["derive"] }

--- a/eight-serve/Cargo.toml
+++ b/eight-serve/Cargo.toml
@@ -13,5 +13,5 @@ include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 
 [dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "signal"] }
-eight = { version = "1.0.0-alpha.2", features = ["expose"] }
+eight = { version = "1.0.0-alpha", features = ["expose"] }
 clap = { version = "4.3", features = ["derive"] }

--- a/eight-serve/Cargo.toml
+++ b/eight-serve/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "eight-serve"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "BSD-3-Clause"
 description = "Expose eight to web"
 homepage = "https://github.com/meppu/eight/tree/main/eight-serve"
 repository = "https://github.com/meppu/eight"
-authors = ["meppu <meppu@proton.me>"]
+authors = ["meppu <crates@meppu.boo>"]
 include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "signal"] }
-eight = { version = "1.0.0-alpha", features = ["expose"] }
+eight = { version = "1.0.0-alpha.2", features = ["expose"] }
 clap = { version = "4.2", features = ["derive"] }

--- a/eight/Cargo.lock
+++ b/eight/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "eight"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/eight/Cargo.toml
+++ b/eight/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eight"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.2"
 edition = "2021"
 license = "BSD-3-Clause"
 description = "Modular asynchronous embedded key-value database"
@@ -8,7 +8,7 @@ homepage = "https://github.com/meppu/eight/tree/main/eight"
 repository = "https://github.com/meppu/eight"
 keywords = ["key-value", "database", "db", "embedded-database", "key-value-store"]
 categories = ["database-implementations", "data-structures", "embedded"]
-authors = ["meppu <meppu@proton.me>"]
+authors = ["meppu <crates@meppu.boo>"]
 include = ["src/**/*", "Cargo.toml", "README.md", "LICENSE"]
 
 [dependencies]


### PR DESCRIPTION
This PR is for managing eight `v1.0.0-alpha.2`